### PR TITLE
Implement previous template extraction

### DIFF
--- a/neogen.el
+++ b/neogen.el
@@ -208,7 +208,7 @@ Return an alist of ((TEMPLATE-STRING . FOUND-VALUE))."
                 (while (match-string match-idx)
                   (push (match-string match-idx) matches)
                   (cl-incf match-idx))
-                (nreverse matches)
+                (setq matches (nreverse matches))
                 (push (cons line matches) extractions)))))))
     extractions))
 
@@ -269,21 +269,27 @@ is being performed: func, class, file, or type."
              (t (push line-str result)))))))
     (nreverse result)))
 
-(defun neogen-template-to-yas-snippet (template)
-  "Convert TEMPLATE lines to a yas snippet."
-  (let ((joined-template (string-join template "\n"))
-        (i 1))
-    (with-temp-buffer
-      (insert joined-template)
-      (goto-char (point-min))
-      (while (not (eobp))
-        (when (looking-at "$1")
-          (delete-char 2)
-          (insert (format "$%d" i))
-          (cl-incf i))
-        (forward-char))
-      (insert "\n")
-      (buffer-string))))
+(defun neogen-template-to-yas-snippet (template existing-extractions)
+  "Convert TEMPLATE lines to a yas snippet.
+
+If EXISTING-EXTRACTIONS is non-nil, it contains an alist of
+elements (TEMPLATE-ITEM . DEFAULT-VALUE)"
+  (let* ((i 1)
+         (yas-template
+          (seq-map
+           (lambda (line)
+             (let ((default-values (cdr (assoc line existing-extractions))))
+               (with-temp-buffer
+                 (insert line)
+                 (goto-char (point-min))
+                 (while (search-forward "$1" nil t)
+                   (if default-values
+                       (replace-match (format "${%d:%s}" i (pop default-values)))
+                     (replace-match (format "$%d" i)))
+                   (cl-incf i))
+                 (buffer-string))))
+           template)))
+    (concat (string-join yas-template "\n") "\n")))
 
 (defvar neogen-overlay nil
   "Overlay to store styling for newly inserted documentation text.")
@@ -331,7 +337,7 @@ is being performed: func, class, file, or type."
         (let* ((extract-data (apply #'neogen-config-extract loc-data))
                (template-lines (neogen-generate-template type template extract-data))
                (existing-extractions (neogen-extract-existing template-lines))
-               (yas-snippet (neogen-template-to-yas-snippet template-lines)))
+               (yas-snippet (neogen-template-to-yas-snippet template-lines existing-extractions)))
           (neogen-insert-template (car loc-data) yas-snippet))))))
 
 (defun neogen-func ()


### PR DESCRIPTION
This PR adds a feature so that when generating a template, the previous section of text is searched for already filled-in matches and is then filled in as defaults for the current template.

Note that this does not destroy the original documentation.